### PR TITLE
move <title> closer to the top of the file

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
+<title>OWLS</title>
 
 	<script src="jquery-3.5.1.min.js"></script>
 	<script>
@@ -241,7 +242,6 @@
 	}
 
 </style>
-<title>OWLS</title>
 </head>
 <body onload="enableToggles()">
 	<div id="grid">


### PR DESCRIPTION
The <title> element was so far down in the HTML file (line 244) that the Ucampas site indexer gave up trying to find it. Moving it up will cause this page's title to show up correctly in the sitemap.